### PR TITLE
Fixed game path verification

### DIFF
--- a/src/ATDGameLoader.cs
+++ b/src/ATDGameLoader.cs
@@ -45,7 +45,9 @@ public class ATDGameLoader : Node2D {
 	public static bool IsOriginalGamePath(string dir) {
 		try {
 			if (!Directory.Exists(dir))
-				return false;
+				throw new System.IO.DirectoryNotFoundException(dir);
+
+			GFXLibrary.pathToAirlineTycoonD = dir;
 
 			ATFile.FindFolder("room");
 			ATFile.FindFile("glbasis.gli");


### PR DESCRIPTION
ATFile works with the pathToAirlineTycoonD variable. Now setting the pathToAirlineTycoonD to the possible path